### PR TITLE
chromium: make events work even if they are timeless

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.chromium.core/src/org/eclipse/tracecompass/analysis/chromium/core/trace/SortingJob.java
+++ b/analysis/org.eclipse.tracecompass.analysis.chromium.core/src/org/eclipse/tracecompass/analysis/chromium/core/trace/SortingJob.java
@@ -25,23 +25,27 @@ final class SortingJob extends Job {
             line = string;
             String key = "\"ts\":"; //$NON-NLS-1$
             int indexOf = string.indexOf(key);
-            if (indexOf == -1) {
-                throw new IllegalStateException("invalid string " + string); //$NON-NLS-1$
-            }
-            int index = indexOf + key.length();
-            int end = string.indexOf(',', index);
-            String number = string.substring(index, end);
-            ts = 0;
-            for (char s : number.toCharArray()) {
-                if (s == '.') {
-                    continue;
+            if (indexOf < 0) {
+                ts = -1;
+            } else {
+                int index = indexOf + key.length();
+                int end = string.indexOf(',', index);
+                if (end == -1) {
+                    end = string.indexOf('}', index);
                 }
-                if (s < '0' || s > '9') {
-                    throw new IllegalStateException("invalid string " + number); //$NON-NLS-1$
+                String number = string.substring(index, end).trim();
+                ts = 0;
+                for (char s : number.toCharArray()) {
+                    if (s == '.') {
+                        continue;
+                    }
+                    if (s < '0' || s > '9') {
+                        throw new IllegalStateException("invalid string " + number); //$NON-NLS-1$
+                    }
+                    ts = (ts * 10) + (s - '0');
                 }
-                ts = (ts * 10) + (s - '0');
+                pos = i;
             }
-            pos = i;
         }
 
         long ts;

--- a/analysis/org.eclipse.tracecompass.analysis.chromium.core/src/org/eclipse/tracecompass/internal/analysis/chromium/core/counters/ChromiumCounterProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.chromium.core/src/org/eclipse/tracecompass/internal/analysis/chromium/core/counters/ChromiumCounterProvider.java
@@ -2,6 +2,7 @@ package org.eclipse.tracecompass.internal.analysis.chromium.core.counters;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.internal.analysis.chromium.core.event.TraceEventEvent;
@@ -43,7 +44,7 @@ public class ChromiumCounterProvider extends AbstractTmfStateProvider {
             return;
         }
         TraceEventEvent traceEvent = (TraceEventEvent) event;
-        if (!traceEvent.getType().equals(TraceEventLookup.get('C'))) {
+        if (!Objects.equals(traceEvent.getType(), (TraceEventLookup.get('C')))) {
             return;
         }
         ITmfStateSystemBuilder ssb = getStateSystemBuilder();


### PR DESCRIPTION
Events with no timestamp will now be assumed to have the time  == -1

Signed-off-by: Matthew Khouzam <matthew.khouzam@gmail.com>